### PR TITLE
xmltextwriter.settings is a virtual property

### DIFF
--- a/Assets/SmartLocalization/Scripts/Editor/FileOperations/LanguageHandlerEditor.cs
+++ b/Assets/SmartLocalization/Scripts/Editor/FileOperations/LanguageHandlerEditor.cs
@@ -254,8 +254,6 @@ public static class LanguageHandlerEditor
 		using(XmlTextWriter xmlWriter = new XmlTextWriter(filePath,Encoding.UTF8))
 		{
 			xmlWriter.Formatting = Formatting.Indented;
-			xmlWriter.Settings.Encoding = Encoding.UTF8;
-			xmlWriter.Settings.Indent = true;
 			xmlWriter.WriteStartDocument();
 			xmlWriter.WriteStartElement("root");
 			xmlWriter.WriteRaw(resxHeader); // Paste in the raw resx header


### PR DESCRIPTION
Fixed problem with XmlTextWriter.Settings in file LanguageHandlerEditor.cs at line 260.