### PR TITLE
-Fixing the reorderable list GUIHelper bug for Unity 2018.2

### DIFF
--- a/Assets/SmartLocalization/Scripts/Editor/ThirdParty/Rotorz/Reorderable List Field/Editor/Internal/GUIHelper.cs
+++ b/Assets/SmartLocalization/Scripts/Editor/ThirdParty/Rotorz/Reorderable List Field/Editor/Internal/GUIHelper.cs
@@ -17,18 +17,20 @@ namespace SmartLocalization.ReorderableList.Internal {
 
 		static GUIHelper() {
 			var tyGUIClip = typeof(GUI).Assembly.GetType("UnityEngine.GUIClip");
-			if (tyGUIClip != null) {
-				var piVisibleRect = tyGUIClip.GetProperty("visibleRect", BindingFlags.Static | BindingFlags.Public);
-				if (piVisibleRect != null)
-					VisibleRect = (Func<Rect>)Delegate.CreateDelegate(typeof(Func<Rect>), piVisibleRect.GetGetMethod());
-			}
-			
-			var miFocusTextInControl = typeof(EditorGUI).GetMethod("FocusTextInControl", BindingFlags.Static | BindingFlags.Public);
-			if (miFocusTextInControl == null)
-				miFocusTextInControl = typeof(GUI).GetMethod("FocusControl", BindingFlags.Static | BindingFlags.Public);
+            if (tyGUIClip != null) {
+                var piVisibleRect = tyGUIClip.GetProperty("visibleRect", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                if (piVisibleRect != null) {
+                    var getMethod = piVisibleRect.GetGetMethod(true) ?? piVisibleRect.GetGetMethod(false);
+                    VisibleRect = (Func<Rect>)Delegate.CreateDelegate(typeof(Func<Rect>), getMethod);
+                }
+            }
 
-			FocusTextInControl = (Action<string>)Delegate.CreateDelegate(typeof(Action<string>), miFocusTextInControl);
-		}
+            var miFocusTextInControl = typeof(EditorGUI).GetMethod("FocusTextInControl", BindingFlags.Static | BindingFlags.Public);
+            if (miFocusTextInControl == null)
+                miFocusTextInControl = typeof(GUI).GetMethod("FocusControl", BindingFlags.Static | BindingFlags.Public);
+
+            FocusTextInControl = (Action<string>)Delegate.CreateDelegate(typeof(Action<string>), miFocusTextInControl);
+        }
 
 		/// <summary>
 		/// Gets visible rectangle within GUI.


### PR DESCRIPTION
Maybe it would be better to update the whole third party library, but I this change was enought to make it work for me.